### PR TITLE
Fix to ``ndg.httpsclient.utils.open_url`` utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ of the SSL peer using ``pyasn1``.
 
 Releases
 ========
+0.4.2
+-----
+ * Fix to bug in ``ndg.httpsclient.utils.open_url`` - duplicate open call.  
+   Nb. This bug and the fix DO NOT affect the ``httplib``and ``urllib2`` 
+   interfaces that this package provides.
+ 
 0.4.1
 -----
  * Added explicit ref to Python 3 in classifier text for Python 3 checking tools.

--- a/ndg/httpsclient/utils.py
+++ b/ndg/httpsclient/utils.py
@@ -217,9 +217,6 @@ def open_url(url, config, data=None, handlers=None):
     return_message = ''
     response = None
     
-    # FIXME
-    response = opener.open(request)
-
     try:
         response = opener.open(request)
         return_message = response.msg

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,12 @@ of the SSL peer using ``pyasn1``.
 
 Releases
 ========
+0.4.2
+-----
+ * Fix to bug in ``ndg.httpsclient.utils.open_url`` - duplicate open call.  
+   Nb. This bug and the fix DO NOT affect the ``httplib``and ``urllib2`` 
+   interfaces that this package provides.
+
 0.4.1
 -----
  * Added explicit ref to Python 3 in classifier text for Python 3 checking tools.
@@ -112,7 +118,7 @@ Options:
     
 setup(
     name='ndg_httpsclient',
-    version="0.4.1",
+    version="0.4.2",
     description='Provides enhanced HTTPS support for httplib and urllib2 using '
                 'PyOpenSSL',
     author='Richard Wilkinson and Philip Kershaw',


### PR DESCRIPTION
Fix to bug in `ndg.httpsclient.utils.open_url` - duplicate open call.  Nb. This bug and the fix DO NOT affect the `httplib`and `urllib2` interfaces that this package provides.
