### PR TITLE
resolve packaging problems leading to warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /ndg_httpsclient.egg-info/
 /dist/
+*.pyc
+.eggs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:14.04
+RUN apt-get -yqq update && apt-get -yqq install python-pip python-dev libffi-dev libxmlsec1-openssl libssl-dev
+WORKDIR /app/
+ADD . /app/
+RUN pip install -e .
+CMD ["python", "setup.py", "test"]

--- a/ndg/__init__.py
+++ b/ndg/__init__.py
@@ -1,11 +1,1 @@
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    # don't prevent use if pkg_resources isn't installed
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__) 
-
-import modulefinder
-for p in __path__:
-    modulefinder.AddPackagePath(__name__, p)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
     long_description=_long_description,
     license='BSD - See ndg/httpsclient/LICENCE file for details',
     packages=find_packages(),
-    namespace_packages=NAMESPACE_PKGS,
+#     namespace_packages=NAMESPACE_PKGS,
 #     package_dir={'ndg.httpsclient': 'ndg/httpsclient'},
     package_data={
         'ndg.httpsclient': [


### PR DESCRIPTION
closes https://github.com/cedadev/ndg_httpsclient/issues/3

Ran tests:
```
$ docker build . -t ndgtest
$ docker run -it ndgtest python setup.py test
```