### PR TITLE
add setuptools to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             'test/pki/ca/*.0'
             ],
     },
-    install_requires=['PyOpenSSL', 'pyasn1>=0.1.1'],
+    install_requires=['PyOpenSSL', 'pyasn1>=0.1.1', 'setuptools>=3.5'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This package depends on working `pkg_resources` which is provided by `setuptools`. Version 3 of `setuptools` is the first version to support Python 3.4.

When I try to use `gunicorn` with `pants`, I am receiving an error stating that `ndg_httpsclient` needs to have this change.